### PR TITLE
Update resource.ps1

### DIFF
--- a/resource.ps1
+++ b/resource.ps1
@@ -1,7 +1,7 @@
 #############################################
 # HelloID-Conn-Prov-Target-Inception-Resource
 #
-# Version: 1.0.1
+# Version: 1.0.2
 #############################################
 # Initialize default values
 $config = $configuration | ConvertFrom-Json
@@ -251,7 +251,14 @@ try {
                     $differentOrgUnits = Compare-Object -ReferenceObject @($targetPosition.belongstoorgunits | Select-Object) -DifferenceObject @($departmentIds | Select-Object)
                     if ($differentOrgUnits.InputObject.count -gt 0) {
                         $orgUnitIdsToAdd = $differentOrgUnits | Where-Object -Property SideIndicator -eq '=>'
-                        $allOrgUnitIdsForPosition = ($targetPosition.belongstoorgunits += $orgUnitIdsToAdd.InputObject)
+                        
+                        if($null -ne $orgUnitIdsToAdd.InputObject) {
+                        	$allOrgUnitIdsForPosition = ($targetPosition.belongstoorgunits += $orgUnitIdsToAdd.InputObject)
+                        }
+                        if($null -eq $orgUnitIdsToAdd.InputObject) {
+                        	$allOrgUnitIdsForPosition = $targetPosition.belongstoorgunits
+                        }
+                        
                         $body = @{
                             state             = 20
                             belongstoorgunits = @($allOrgUnitIdsForPosition)


### PR DESCRIPTION
When $orgUnitIdsToAdd is null, a 'null' entry is added to $allOrgUnitIdsForPosition. The Inception api doesn't accept null values and will result in a null-value-error.